### PR TITLE
Fixed semicolon typos in task 'clean-db'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,9 +110,9 @@ gulp.task('clean-db', function() {
     databaseCleaner.clean(db, function() {
       console.log('done');
       db.close();
-    });;
+    });
   });
-})
+});
 
 gulp.task('nodemon-start', function() {
   nodemon({


### PR DESCRIPTION
There was a line with 2 semicolons and a line with no semicolons